### PR TITLE
use numpy 1.x.x

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -19,3 +19,4 @@ torchvision>=0.8.2
 pillow>=8.0.0
 tensorflow
 tensorflow_hub
+numpy<2.0.0


### PR DESCRIPTION
we cannot use numpy 2.xx due to both pytorch and tensorflow now